### PR TITLE
Properly resolve the global linc namespace from a haxe package.

### DIFF
--- a/glew/GLEW.hx
+++ b/glew/GLEW.hx
@@ -26,7 +26,7 @@ extern class GLEW {
         }
     }
 
-    @:native('linc::glew::init')
+    @:native('::linc::glew::init')
     static function init() : Int;
 
     @:native('(bool)glewIsSupported')


### PR DESCRIPTION
When calling GLEW.init from a package other than the root this function fails to resolve.